### PR TITLE
Keep custom lms version for github packages gem

### DIFF
--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.email    = ['seah@shuber.io', 'sbfaulkner@gmail.com', 'billy.monk@gmail.com', 'saghaulor@gmail.com']
   s.homepage = 'http://github.com/attr-encrypted/attr_encrypted'
   s.license = 'MIT'
+  s.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/acima-credit'
 
   s.has_rdoc = false
   s.rdoc_options = ['--line-numbers', '--inline-source', '--main', 'README.rdoc']
@@ -57,8 +58,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('simplecov-rcov')
   s.add_development_dependency("codeclimate-test-reporter", '<= 0.6.0')
 
-  s.cert_chain  = ['certs/saghaulor.pem']
-  s.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if $0 =~ /gem\z/
+  # s.cert_chain  = ['certs/saghaulor.pem']
+  # s.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if $0 =~ /gem\z/
 
   s.post_install_message = "\n\n\nWARNING: Several insecure default options and features were deprecated in attr_encrypted v2.0.0.\n
 Additionally, there was a bug in Encryptor v2.0.0 that insecurely encrypted data when using an AES-*-GCM algorithm.\n

--- a/lib/attr_encrypted/version.rb
+++ b/lib/attr_encrypted/version.rb
@@ -13,7 +13,7 @@ module AttrEncrypted
     #
     #   Version.string # '1.0.2'
     def self.string
-      [MAJOR, MINOR, PATCH].join('.')
+      [MAJOR, MINOR, PATCH, 'lms'].join('.')
     end
   end
 end


### PR DESCRIPTION
This explicitly creates a lms version (3.1.0.lms) since it's different than master 3.1.0. Merging will effect the current lms setup as it will change the version in the Gemfile.lock on lms.